### PR TITLE
Add docker entrypoint and compose files

### DIFF
--- a/DOCKER_COMMANDS.md
+++ b/DOCKER_COMMANDS.md
@@ -1,0 +1,246 @@
+# Docker Commands для Queue Management API
+
+Этот проект теперь поддерживает различные команды для запуска через Docker с помощью `docker-entrypoint.sh` и `docker-compose.yml`.
+
+## Доступные команды в docker-entrypoint.sh
+
+### Основные команды сервера
+
+- `server` - Запуск production сервера
+- `server-dev` - Запуск development сервера с auto-reload
+- `migrate` - Запуск миграций базы данных (Alembic)
+- `create-tables` - Создание таблиц в базе данных
+- `shell` - Запуск Python shell
+- `bash` - Запуск bash shell
+- `test` - Запуск тестов
+- `worker` - Запуск background worker (заготовка для Celery)
+- `scheduler` - Запуск scheduler (заготовка для Celery Beat)
+- `manage` - Запуск management команд
+
+## Использование с docker-compose
+
+### Базовые сервисы (запускаются по умолчанию)
+
+```bash
+# Запуск всех базовых сервисов (db, redis, backend в dev режиме)
+docker-compose up
+
+# Запуск в фоне
+docker-compose up -d
+
+# Просмотр логов
+docker-compose logs -f backend
+```
+
+### Специальные профили
+
+#### Production режим
+
+```bash
+# Запуск production сервера
+docker-compose --profile production up backend-prod
+
+# Запуск с базовыми сервисами
+docker-compose --profile production up db redis backend-prod
+```
+
+#### Миграции
+
+```bash
+# Запуск миграций
+docker-compose --profile migration up backend-migrate
+
+# Создание таблиц
+docker-compose --profile init up backend-init
+```
+
+#### Тесты
+
+```bash
+# Запуск тестов
+docker-compose --profile test up backend-test
+
+# Запуск тестов с конкретными параметрами
+docker-compose --profile test run --rm backend-test test -v
+```
+
+#### Background задачи
+
+```bash
+# Запуск worker'а
+docker-compose --profile worker up backend-worker
+
+# Запуск scheduler'а
+docker-compose --profile scheduler up backend-scheduler
+
+# Запуск и worker'а и scheduler'а
+docker-compose --profile worker --profile scheduler up
+```
+
+## Прямое использование docker run
+
+### Основные команды
+
+```bash
+# Сборка образа
+docker build -t queue-app-backend ./backend
+
+# Запуск development сервера
+docker run --rm -p 8000:8000 queue-app-backend server-dev
+
+# Запуск production сервера
+docker run --rm -p 8000:8000 queue-app-backend server
+
+# Создание таблиц
+docker run --rm queue-app-backend create-tables
+
+# Запуск Python shell
+docker run --rm -it queue-app-backend shell
+
+# Запуск bash
+docker run --rm -it queue-app-backend bash
+```
+
+### С переменными окружения
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e DATABASE_URL=postgresql://user:pass@host:5432/db \
+  -e REDIS_URL=redis://redis:6379 \
+  -e ENVIRONMENT=production \
+  queue-app-backend server
+```
+
+## Полезные команды для разработки
+
+### Быстрый запуск для разработки
+
+```bash
+# Запуск всех необходимых сервисов для разработки
+docker-compose up -d
+
+# Перезапуск только backend
+docker-compose restart backend
+
+# Остановка всех сервисов
+docker-compose down
+```
+
+### Отладка и консоль
+
+```bash
+# Войти в контейнер с backend
+docker-compose exec backend bash
+
+# Запустить Python shell в контейнере
+docker-compose exec backend python
+
+# Выполнить произвольную команду
+docker-compose exec backend python -c "from app.core.database import engine; print(engine.url)"
+```
+
+### Логи и мониторинг
+
+```bash
+# Просмотр логов всех сервисов
+docker-compose logs -f
+
+# Просмотр логов конкретного сервиса
+docker-compose logs -f backend
+
+# Просмотр последних 100 строк логов
+docker-compose logs --tail=100 backend
+```
+
+### Очистка
+
+```bash
+# Остановка и удаление контейнеров
+docker-compose down
+
+# Удаление с volume'ами (ВНИМАНИЕ: удалит данные БД)
+docker-compose down -v
+
+# Пересборка образов
+docker-compose build
+
+# Пересборка без кэша
+docker-compose build --no-cache
+```
+
+## Структура конфигурации
+
+### Healthchecks
+
+Все сервисы имеют healthcheck'и:
+- PostgreSQL: `pg_isready`
+- Redis: `redis-cli ping`
+
+Backend сервисы ждут готовности базы данных и Redis перед запуском.
+
+### Profiles
+
+Используются профили для группировки сервисов:
+- `production` - production сервер
+- `migration` - миграции
+- `init` - инициализация БД
+- `test` - тесты
+- `worker` - background worker
+- `scheduler` - scheduler
+
+### Переменные окружения
+
+Все сервисы используют единые переменные:
+- `DATABASE_URL` - URL подключения к PostgreSQL
+- `REDIS_URL` - URL подключения к Redis
+- `ENVIRONMENT` - окружение (development/production/testing)
+
+## Примеры workflow'ов
+
+### Первый запуск проекта
+
+```bash
+# 1. Клонирование и переход в проект
+git clone <repo>
+cd <project>
+
+# 2. Сборка и запуск
+docker-compose build
+docker-compose up -d
+
+# 3. Создание таблиц (если нет миграций)
+docker-compose --profile init up backend-init
+
+# 4. Проверка работы
+curl http://localhost:8000/health
+```
+
+### Разработка
+
+```bash
+# Запуск для разработки
+docker-compose up -d
+
+# Просмотр логов при разработке
+docker-compose logs -f backend
+
+# При изменении зависимостей
+docker-compose build backend
+docker-compose up -d
+
+# Выполнение тестов
+docker-compose --profile test up backend-test
+```
+
+### Production деплой
+
+```bash
+# Запуск production
+docker-compose --profile production up -d db redis backend-prod
+
+# Если нужны миграции
+docker-compose --profile migration up backend-migrate
+
+# Запуск background задач
+docker-compose --profile worker --profile scheduler up -d
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+.PHONY: help build up down logs shell bash test migrate init prod worker scheduler clean
+
+# Переменные
+COMPOSE = docker-compose
+BACKEND_SERVICE = backend
+
+help: ## Показать эту справку
+	@echo "Доступные команды:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+build: ## Собрать все образы
+	$(COMPOSE) build
+
+up: ## Запустить сервисы для разработки
+	$(COMPOSE) up -d
+
+down: ## Остановить все сервисы
+	$(COMPOSE) down
+
+logs: ## Показать логи backend сервиса
+	$(COMPOSE) logs -f $(BACKEND_SERVICE)
+
+logs-all: ## Показать логи всех сервисов
+	$(COMPOSE) logs -f
+
+shell: ## Запустить Python shell в контейнере
+	$(COMPOSE) exec $(BACKEND_SERVICE) ./docker-entrypoint.sh shell
+
+bash: ## Запустить bash в контейнере
+	$(COMPOSE) exec $(BACKEND_SERVICE) bash
+
+test: ## Запустить тесты
+	$(COMPOSE) --profile test up --build backend-test
+
+migrate: ## Запустить миграции
+	$(COMPOSE) --profile migration up --build backend-migrate
+
+init: ## Создать таблицы в БД
+	$(COMPOSE) --profile init up --build backend-init
+
+prod: ## Запустить production сервер
+	$(COMPOSE) --profile production up -d db redis backend-prod
+
+worker: ## Запустить background worker
+	$(COMPOSE) --profile worker up -d backend-worker
+
+scheduler: ## Запустить scheduler
+	$(COMPOSE) --profile scheduler up -d backend-scheduler
+
+full-prod: ## Запустить полный production стек
+	$(COMPOSE) --profile production --profile worker --profile scheduler up -d
+
+restart: ## Перезапустить backend сервис
+	$(COMPOSE) restart $(BACKEND_SERVICE)
+
+rebuild: ## Пересобрать и перезапустить backend
+	$(COMPOSE) build $(BACKEND_SERVICE)
+	$(COMPOSE) up -d $(BACKEND_SERVICE)
+
+clean: ## Остановить и удалить все контейнеры
+	$(COMPOSE) down
+
+clean-all: ## Остановить и удалить все контейнеры и volume'ы
+	$(COMPOSE) down -v
+
+status: ## Показать статус сервисов
+	$(COMPOSE) ps
+
+# Команды для разработки
+dev-setup: build init up ## Первоначальная настройка для разработки
+
+dev-reset: clean-all dev-setup ## Полный сброс среды разработки
+
+# Полезные команды
+exec: ## Выполнить команду в контейнере (use: make exec CMD="command")
+	$(COMPOSE) exec $(BACKEND_SERVICE) $(CMD)
+
+run: ## Запустить одноразовую команду (use: make run CMD="command")
+	$(COMPOSE) run --rm $(BACKEND_SERVICE) ./docker-entrypoint.sh $(CMD)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,8 +14,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
+# Make entrypoint script executable
+RUN chmod +x docker-entrypoint.sh
+
 # Expose port
 EXPOSE 8000
 
-# Command to run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Set entrypoint
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# Default command
+CMD ["server-dev"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -e
+
+# Функция для ожидания готовности базы данных
+wait_for_db() {
+    echo "Waiting for database to be ready..."
+    while ! python -c "
+import asyncpg
+import asyncio
+import os
+
+async def check_db():
+    try:
+        conn = await asyncpg.connect(os.getenv('DATABASE_URL'))
+        await conn.close()
+        print('Database is ready!')
+        return True
+    except Exception as e:
+        print(f'Database not ready: {e}')
+        return False
+
+if not asyncio.run(check_db()):
+    exit(1)
+" 2>/dev/null; do
+        echo "Database is unavailable - sleeping..."
+        sleep 2
+    done
+}
+
+# Функция для ожидания готовности Redis
+wait_for_redis() {
+    echo "Waiting for Redis to be ready..."
+    while ! python -c "
+import redis
+import os
+
+try:
+    r = redis.from_url(os.getenv('REDIS_URL', 'redis://redis:6379'))
+    r.ping()
+    print('Redis is ready!')
+except Exception as e:
+    print(f'Redis not ready: {e}')
+    exit(1)
+" 2>/dev/null; do
+        echo "Redis is unavailable - sleeping..."
+        sleep 2
+    done
+}
+
+# Функция для запуска миграций
+run_migrations() {
+    echo "Running database migrations..."
+    if [ -f "alembic.ini" ]; then
+        alembic upgrade head
+    else
+        echo "No alembic.ini found, skipping migrations"
+    fi
+}
+
+# Функция для создания таблиц
+create_tables() {
+    echo "Creating database tables..."
+    python -c "
+import asyncio
+from app.core.database import create_tables
+asyncio.run(create_tables())
+"
+}
+
+# Основная логика выбора команды
+case "$1" in
+    "server")
+        echo "Starting FastAPI server..."
+        wait_for_db
+        wait_for_redis
+        create_tables
+        exec uvicorn main:app --host 0.0.0.0 --port 8000
+        ;;
+    "server-dev")
+        echo "Starting FastAPI server in development mode..."
+        wait_for_db
+        wait_for_redis
+        create_tables
+        exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+        ;;
+    "migrate")
+        echo "Running database migrations..."
+        wait_for_db
+        run_migrations
+        ;;
+    "create-tables")
+        echo "Creating database tables..."
+        wait_for_db
+        create_tables
+        ;;
+    "shell")
+        echo "Starting Python shell..."
+        exec python
+        ;;
+    "bash")
+        echo "Starting bash shell..."
+        exec /bin/bash
+        ;;
+    "test")
+        echo "Running tests..."
+        wait_for_db
+        wait_for_redis
+        if [ -f "pytest.ini" ] || [ -f "pyproject.toml" ]; then
+            exec pytest "${@:2}"
+        else
+            echo "No test configuration found"
+            exit 1
+        fi
+        ;;
+    "worker")
+        echo "Starting background worker..."
+        wait_for_db
+        wait_for_redis
+        # Здесь можно добавить команду для запуска Celery worker или другого worker'а
+        echo "Worker functionality not implemented yet"
+        ;;
+    "scheduler")
+        echo "Starting scheduler..."
+        wait_for_db
+        wait_for_redis
+        # Здесь можно добавить команду для запуска Celery beat или другого scheduler'а
+        echo "Scheduler functionality not implemented yet"
+        ;;
+    "manage")
+        echo "Running management command: ${@:2}"
+        wait_for_db
+        wait_for_redis
+        exec python -m app.cli "${@:2}"
+        ;;
+    *)
+        echo "Available commands:"
+        echo "  server          - Start production server"
+        echo "  server-dev      - Start development server with reload"
+        echo "  migrate         - Run database migrations"
+        echo "  create-tables   - Create database tables"
+        echo "  shell           - Start Python shell"
+        echo "  bash            - Start bash shell"
+        echo "  test            - Run tests"
+        echo "  worker          - Start background worker"
+        echo "  scheduler       - Start scheduler"
+        echo "  manage          - Run management command"
+        echo ""
+        echo "Usage: docker-entrypoint.sh [command] [args...]"
+        exit 1
+        ;;
+esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - queue_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
@@ -22,7 +27,13 @@ services:
       - "6379:6379"
     networks:
       - queue_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
+  # Основной backend сервис для разработки
   backend:
     build: 
       context: ./backend
@@ -35,13 +46,144 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - ./backend:/app
     networks:
       - queue_network
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    command: ["server-dev"]
+
+  # Production backend сервис
+  backend-prod:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: queue_app_backend_prod
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/queue_app
+      - REDIS_URL=redis://redis:6379
+      - ENVIRONMENT=production
+    ports:
+      - "8001:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - queue_network
+    command: ["server"]
+    profiles:
+      - production
+
+  # Сервис для миграций
+  backend-migrate:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/queue_app
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./backend:/app
+    networks:
+      - queue_network
+    command: ["migrate"]
+    profiles:
+      - migration
+
+  # Сервис для создания таблиц
+  backend-init:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/queue_app
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./backend:/app
+    networks:
+      - queue_network
+    command: ["create-tables"]
+    profiles:
+      - init
+
+  # Сервис для тестов
+  backend-test:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/queue_app_test
+      - REDIS_URL=redis://redis:6379
+      - ENVIRONMENT=testing
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./backend:/app
+    networks:
+      - queue_network
+    command: ["test"]
+    profiles:
+      - test
+
+  # Background worker сервис
+  backend-worker:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: queue_app_worker
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/queue_app
+      - REDIS_URL=redis://redis:6379
+      - ENVIRONMENT=production
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./backend:/app
+    networks:
+      - queue_network
+    command: ["worker"]
+    profiles:
+      - worker
+
+  # Scheduler сервис
+  backend-scheduler:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: queue_app_scheduler
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/queue_app
+      - REDIS_URL=redis://redis:6379
+      - ENVIRONMENT=production
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./backend:/app
+    networks:
+      - queue_network
+    command: ["scheduler"]
+    profiles:
+      - scheduler
 
 volumes:
   postgres_data:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `docker-entrypoint.sh` and update `docker-compose.yml` to enable running various application commands within Docker.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change streamlines development, testing, and deployment by providing standardized Docker commands for tasks like running the server (dev/prod), database migrations, creating tables, running tests, and future background workers/schedulers. It also includes health checks and proper service dependency management, along with a `Makefile` and `DOCKER_COMMANDS.md` for ease of use and documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e2df280-b74e-4caf-8593-45c5e5efbf5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e2df280-b74e-4caf-8593-45c5e5efbf5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>